### PR TITLE
Ensure times output as UTC regardless of input time zone.

### DIFF
--- a/src/main/scala/icalendar/ValueType.scala
+++ b/src/main/scala/icalendar/ValueType.scala
@@ -27,7 +27,6 @@ object ValueTypes {
 
   case class DateTime(dt: ZonedDateTime) extends ValueType
   object DateTime {
-    // TODO require or convert to UTC here?
     implicit def fromZonedDateTime(dt: ZonedDateTime): DateTime = DateTime(dt)
   }
 

--- a/src/main/scala/icalendar/ical/Writer.scala
+++ b/src/main/scala/icalendar/ical/Writer.scala
@@ -1,6 +1,7 @@
 package icalendar
 package ical
 
+import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 
 /**
@@ -22,7 +23,10 @@ object Writer {
         case '\n' => "\\n"
         case other => other.toString
       }
-    case date: DateTime => date.dt.format(DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'"))
+    case date: DateTime => {
+      val utc = date.dt.withZoneSameInstant(ZoneOffset.UTC)
+      utc.format(DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'"))
+    }
     case value: CalAddress => valueAsIcal(value.value)
     case Uri(uri) => uri.toString
     case EitherType(Left(payload)) => valueAsIcal(payload)

--- a/src/test/scala/icalendar/ical/objectspecification/PropertyValueDataTypes.scala
+++ b/src/test/scala/icalendar/ical/objectspecification/PropertyValueDataTypes.scala
@@ -1,0 +1,25 @@
+package icalendar
+package ical
+package objectspecification
+
+import java.time.{ZonedDateTime, ZoneId}
+
+import org.scalatest._
+
+import Properties._
+import Writer._
+
+class PropertyValueDataTypes extends WordSpec with Matchers {
+  "3.3 Property Value Data Types" should {
+    "3.3.5 Date-Time" should {
+      "with time provided as UTC+3.00" in {
+        asIcal(
+          Dtstart(ZonedDateTime.of(1997, 9, 3, 19, 30, 0, 0, ZoneId.of("Europe/Sofia")))
+        ) should haveLines (
+          // expect time back as UTC
+          "DTSTART:19970903T163000Z"
+        )
+      }
+    }
+  }
+}


### PR DESCRIPTION
This fixes time zone handling when the input times are not provided as UTC.

See section 4.3.5 of [RFC 2445](http://www.ietf.org/rfc/rfc2445.txt)

```
   FORM #2: DATE WITH UTC TIME

   The date with UTC time, or absolute time, is identified by a LATIN
   CAPITAL LETTER Z suffix character (US-ASCII decimal 90), the UTC
   designator, appended to the time value. For example, the following
   represents January 19, 1998, at 0700 UTC:

     DTSTART:19980119T070000Z
```

The test was providing input in UTC only, which wasn't triggering the bug.